### PR TITLE
feat!: From now on, it's assumed that the origin's content …

### DIFF
--- a/API.md
+++ b/API.md
@@ -411,6 +411,7 @@ const mediaTailorProps: MediaTailorProps = { ... }
 | --- | --- | --- |
 | <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorProps.property.adDecisionServerUrl">adDecisionServerUrl</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorProps.property.videoContentSourceUrl">videoContentSourceUrl</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorProps.property.configurationAliases">configurationAliases</a></code> | <code>object</code> | *No description.* |
 | <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorProps.property.slateAdUrl">slateAdUrl</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -432,6 +433,16 @@ public readonly videoContentSourceUrl: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `configurationAliases`<sup>Optional</sup> <a name="configurationAliases" id="awscdk-mediatailor-cloudfront-construct.MediaTailorProps.property.configurationAliases"></a>
+
+```typescript
+public readonly configurationAliases: object;
+```
+
+- *Type:* object
 
 ---
 
@@ -461,6 +472,7 @@ const mediaTailorWithCloudFrontProps: MediaTailorWithCloudFrontProps = { ... }
 | --- | --- | --- |
 | <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorWithCloudFrontProps.property.adDecisionServerUrl">adDecisionServerUrl</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorWithCloudFrontProps.property.videoContentSourceUrl">videoContentSourceUrl</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorWithCloudFrontProps.property.configurationAliases">configurationAliases</a></code> | <code>object</code> | *No description.* |
 | <code><a href="#awscdk-mediatailor-cloudfront-construct.MediaTailorWithCloudFrontProps.property.slateAdUrl">slateAdUrl</a></code> | <code>string</code> | *No description.* |
 
 ---
@@ -482,6 +494,16 @@ public readonly videoContentSourceUrl: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `configurationAliases`<sup>Optional</sup> <a name="configurationAliases" id="awscdk-mediatailor-cloudfront-construct.MediaTailorWithCloudFrontProps.property.configurationAliases"></a>
+
+```typescript
+public readonly configurationAliases: object;
+```
+
+- *Type:* object
 
 ---
 

--- a/src/MediaTailor.ts
+++ b/src/MediaTailor.ts
@@ -7,6 +7,7 @@ export interface MediaTailorProps {
   readonly videoContentSourceUrl: string;
   readonly adDecisionServerUrl: string;
   readonly slateAdUrl?: string;
+  readonly configurationAliases?: object;
 }
 
 export class MediaTailor extends Construct {
@@ -16,18 +17,18 @@ export class MediaTailor extends Construct {
     videoContentSourceUrl,
     adDecisionServerUrl,
     slateAdUrl,
+    configurationAliases,
   }: MediaTailorProps) {
 
     super(scope, id);
 
-    const arr = Fn.split('/', videoContentSourceUrl);
-
     // Create EMT config
     this.config = new CfnPlaybackConfiguration(this, 'CfnPlaybackConfiguration', {
       name: `${crypto.randomUUID()}`,
-      videoContentSourceUrl: `https://${Fn.select(2, arr)}/${Fn.select(3, arr)}/${Fn.select(4, arr)}/${Fn.select(5, arr)}/`, // Ugly
+      videoContentSourceUrl: `https://${Fn.select(2, Fn.split('/', videoContentSourceUrl))}/out/v1/`, // Assuming MediaPackage endpoint
       adDecisionServerUrl,
       slateAdUrl,
+      configurationAliases,
     });
   }
 }


### PR DESCRIPTION
…path no more includes endpoint id. It should be provided at playback or session initialization time.

Fixes #